### PR TITLE
Visual studio fixes

### DIFF
--- a/Proguard.Build.Tasks/Tasks/Proguard.cs
+++ b/Proguard.Build.Tasks/Tasks/Proguard.cs
@@ -67,10 +67,18 @@ namespace BitterFudge.Proguard.Build.Tasks
         protected override string GenerateCommandLineCommands ()
         {
             var builder = new CommandLineBuilder ();
+
+            var monoPlatformJarPath = MonoPlatformJarPath;
+            if (OS.IsWindows)
+            {
+                // Escape paths that have spaces or parentheticals.
+                monoPlatformJarPath = "\"" + MonoPlatformJarPath + "\"";
+            }
+
             builder.AppendSwitchIfNotNull ("-injars ", CompiledJavaDirectory);
             builder.AppendSwitchIfNotNull ("-injars ", AdditionalLibraries, ":");
             builder.AppendSwitchIfNotNull ("-libraryjars ", JavaPlatformJarPath);
-            builder.AppendSwitchIfNotNull ("-libraryjars ", MonoPlatformJarPath);
+            builder.AppendSwitchIfNotNull ("-libraryjars ", monoPlatformJarPath);
             builder.AppendSwitchIfNotNull ("-outjar ", OutputDirectory);
             builder.AppendSwitchIfNotNull ("-include ", Config);
             if (File.Exists (UserConfig)) {


### PR DESCRIPTION
With these changes I can run XamGuard  under visual studio.  The first one honors PROGUARD_HOME and if not set will set it to the default.  Without this change proguard.bat can't find proguard.

The second change escapes the mono dll path properly for the batch file.
