### PR TITLE
fixed *.jar files could not be found in library projects directory since Xamarin 3.5

### DIFF
--- a/Proguard.Build.Tasks/Tasks/Proguard.cs
+++ b/Proguard.Build.Tasks/Tasks/Proguard.cs
@@ -71,7 +71,7 @@ namespace BitterFudge.Proguard.Build.Tasks
             var tempDirectory = Path.Combine (OutputDirectory, "tmp");
             LibraryProjectsTempDirectory = Path.Combine (tempDirectory, "library_projects");
 
-            MoveFiles (LibraryProjectsDirectory, "*.jar", SearchOption.TopDirectoryOnly, LibraryProjectsTempDirectory, "library project jar");
+            MoveFiles (LibraryProjectsDirectory, "*.jar", SearchOption.AllDirectories, LibraryProjectsTempDirectory, "library project jar");
             GenerateConfiguration ();
             var success = base.Execute ();
 


### PR DESCRIPTION
Root of library projects directory now does not contain *.jar files.
